### PR TITLE
MemberCreate에서 필요없는 encryptedPwd 필드 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,12 @@ dependencies {
 	annotationProcessor('com.querydsl:querydsl-apt:5.0.0:jpa')
 
 	//암호화
-	implementation 'commons-codec:commons-codec:1.11'
+	implementation 'commons-codec:commons-codec:1.15'
+
+	//Swagger 2
+	implementation 'io.springfox:springfox-swagger2:2.9.2'
+	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
+	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kmong/api/member/request/MemberCreate.java
+++ b/src/main/java/com/kmong/api/member/request/MemberCreate.java
@@ -13,21 +13,19 @@ public class MemberCreate {
     private String id;
     private String email;
     private String pwd;
-    private String encryptedPwd;
 
     @Builder
     public MemberCreate(String id, String email, String pwd) {
         this.id = id;
         this.email = email;
         this.pwd = pwd;
-        this.encryptedPwd = PwdEncryption.encrypt(pwd);
     }
 
     public Member toMember() {
         return Member.builder()
                     .id(id)
                     .email(email)
-                    .pwd(encryptedPwd)
+                    .pwd(PwdEncryption.encrypt(pwd))
                     .build();
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,6 @@ logging.level.org.springframework.orm.jpa.JpaTransactionManager=DEBUG
 logging.level.org.hibernate.resource.transaction=DEBUG
 
 logging.level.org.hibernate.type=TRACE
+
+#Swagger2
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
@@ -2,6 +2,7 @@ package com.kmong.api.member.controller;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kmong.api.config.encrypt.PwdEncryption;
 import com.kmong.api.member.repository.MemberRepository;
 import com.kmong.api.member.domain.Member;
 import com.kmong.api.member.request.MemberCreate;
@@ -65,7 +66,7 @@ public class MemberControllerTest {
 
         assertEquals(memberCreate.getId(), member.getId());
         assertEquals(memberCreate.getEmail(), member.getEmail());
-        assertEquals(memberCreate.getEncryptedPwd(), member.getPwd());
+        assertEquals(PwdEncryption.encrypt(memberCreate.getPwd()), member.getPwd());
     }
 
     @Test

--- a/src/test/java/com/kmong/api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kmong/api/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.kmong.api.member.service;
 
+import com.kmong.api.config.encrypt.PwdEncryption;
 import com.kmong.api.member.domain.Member;
 import com.kmong.api.member.repository.MemberRepository;
 import com.kmong.api.member.request.MemberCreate;
@@ -39,7 +40,7 @@ public class MemberServiceTest {
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(memberCreate.getId(), member.getId());
         assertEquals(memberCreate.getEmail(), member.getEmail());
-        assertEquals(memberCreate.getEncryptedPwd(), member.getPwd());
+        assertEquals(PwdEncryption.encrypt(memberCreate.getPwd()), member.getPwd());
     }
 
 }


### PR DESCRIPTION
1. MemberCreate에서 필요없는 encryptedPwd 필드를 삭제하고 Member 객체만들 때 비밀번호 암호화해서 넘겨주도록 수정