### PR TITLE
배포를 위한 설정 변경

### DIFF
--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
1. 배포를 위해 system.properties 파일 추가
 - 헤로쿠 배포시 JDK 11로 실행되게 하기 위함