### PR TITLE
plain jar 생성 막기 위한 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,3 +47,7 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+jar {
+	enabled = false
+}


### PR DESCRIPTION
plain jar로 인해 헤로쿠 배포에 문제가 발생하여 plain jar 생성을 막기 위한 설정 추가