### PR TITLE
회원 유효성체크 로직 추가 및 응답 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	implementation 'io.springfox:springfox-swagger2:2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: '2.9.2'
 	implementation group: 'io.springfox', name: 'springfox-swagger2', version: '2.9.2'
+
+	//validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/kmong/api/common/exception/KmongApiException.java
+++ b/src/main/java/com/kmong/api/common/exception/KmongApiException.java
@@ -1,0 +1,18 @@
+package com.kmong.api.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class KmongApiException extends RuntimeException {
+
+    public KmongApiException(String message) {
+        super(message);
+    }
+
+    public KmongApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public abstract int getStatusCode();
+
+}

--- a/src/main/java/com/kmong/api/common/exception/KmongNotFoundException.java
+++ b/src/main/java/com/kmong/api/common/exception/KmongNotFoundException.java
@@ -1,0 +1,16 @@
+package com.kmong.api.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class KmongNotFoundException extends KmongApiException {
+
+    public KmongNotFoundException(String message) {
+        super(message);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 404;
+    }
+}

--- a/src/main/java/com/kmong/api/common/exception/KmongNotFoundListException.java
+++ b/src/main/java/com/kmong/api/common/exception/KmongNotFoundListException.java
@@ -1,0 +1,19 @@
+package com.kmong.api.common.exception;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class KmongNotFoundListException extends KmongNotFoundException {
+
+    private List list;
+
+    public KmongNotFoundListException(String message, List list) {
+        super(message);
+        this.list = list;
+    }
+
+}

--- a/src/main/java/com/kmong/api/common/response/ListResponse.java
+++ b/src/main/java/com/kmong/api/common/response/ListResponse.java
@@ -1,0 +1,24 @@
+package com.kmong.api.common.response;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+public class ListResponse<T> extends Response{
+
+    private List<T> objects;
+
+    public ListResponse(String code, String message) {
+        super(code, message);
+    }
+
+    @Builder
+    public ListResponse(String code, String message, List<T> objects) {
+        super(code, message);
+        this.objects = objects;
+    }
+}

--- a/src/main/java/com/kmong/api/common/response/Response.java
+++ b/src/main/java/com/kmong/api/common/response/Response.java
@@ -1,0 +1,16 @@
+package com.kmong.api.common.response;
+
+import lombok.Getter;
+
+@Getter
+public class Response {
+
+    private final String code;
+    private final String message;
+
+    public Response(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+}

--- a/src/main/java/com/kmong/api/common/response/Response.java
+++ b/src/main/java/com/kmong/api/common/response/Response.java
@@ -1,12 +1,14 @@
 package com.kmong.api.common.response;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class Response {
 
-    private final String code;
-    private final String message;
+    private String code;
+    private String message;
 
     public Response(String code, String message) {
         this.code = code;

--- a/src/main/java/com/kmong/api/common/response/SingleResponse.java
+++ b/src/main/java/com/kmong/api/common/response/SingleResponse.java
@@ -2,14 +2,18 @@ package com.kmong.api.common.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
-public class SingleResponse extends Response {
+@Setter
+@NoArgsConstructor
+public class SingleResponse<T> extends Response {
 
-    private Object object;
+    private T object;
 
     @Builder
-    public SingleResponse(String code, String message, Object object) {
+    public SingleResponse(String code, String message, T object) {
         super(code, message);
         this.object = object;
     }

--- a/src/main/java/com/kmong/api/common/response/SingleResponse.java
+++ b/src/main/java/com/kmong/api/common/response/SingleResponse.java
@@ -1,0 +1,17 @@
+package com.kmong.api.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SingleResponse extends Response {
+
+    private Object object;
+
+    @Builder
+    public SingleResponse(String code, String message, Object object) {
+        super(code, message);
+        this.object = object;
+    }
+
+}

--- a/src/main/java/com/kmong/api/common/response/ValidationExceptionResponse.java
+++ b/src/main/java/com/kmong/api/common/response/ValidationExceptionResponse.java
@@ -1,0 +1,24 @@
+package com.kmong.api.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+public class ValidationExceptionResponse extends Response {
+
+    private Map<String, String> validation = new HashMap<>();
+
+    @Builder
+    public ValidationExceptionResponse(String code, String message, Map<String, String> validation) {
+        super(code, message);
+        this.validation = validation;
+    }
+
+    public void addValidation(String fieldName, String errorMessage) {
+        this.validation.put(fieldName, errorMessage);
+    }
+
+}

--- a/src/main/java/com/kmong/api/config/WebConfig.java
+++ b/src/main/java/com/kmong/api/config/WebConfig.java
@@ -9,15 +9,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    public static final String LOGIN_URL = "/member/login";
-    public static final String JOIN_URL = "/member/join";
+    public static final String MEMBER_LOGIN_URL = "/member/login";
+
+    public static final String MEMBER_JOIN_URL = "/member/join";
+
+    public static final String PRODUCT_LIST_URL = "/product/list";
 
     public static final String DB_URL = "/h2-console/*";
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new AuthInterceptor())
-                .excludePathPatterns(LOGIN_URL, JOIN_URL, DB_URL)
+                .excludePathPatterns(MEMBER_LOGIN_URL, MEMBER_JOIN_URL, PRODUCT_LIST_URL, DB_URL)
                 .excludePathPatterns("/swagger-resources/**", "/webjars/**",
                         "/v2/**", "/swagger-ui.html/**");;
     }

--- a/src/main/java/com/kmong/api/config/advice/ExceptionAdvice.java
+++ b/src/main/java/com/kmong/api/config/advice/ExceptionAdvice.java
@@ -1,0 +1,39 @@
+package com.kmong.api.config.advice;
+
+import com.kmong.api.common.response.Response;
+import com.kmong.api.common.exception.KmongApiException;
+import com.kmong.api.common.response.ValidationExceptionResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity hasInvalidParam(MethodArgumentNotValidException e) {
+        ValidationExceptionResponse response = ValidationExceptionResponse.builder()
+                                                                            .code("400")
+                                                                            .message("잘못된 요청입니다.")
+                                                                            .validation(new HashMap<>())
+                                                                            .build();
+
+        for (FieldError fieldError : e.getFieldErrors()) {
+            response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(KmongApiException.class)
+    public ResponseEntity kmongApiException(KmongApiException e) {
+        int statusCode = e.getStatusCode();
+        Response body = new Response(String.valueOf(statusCode), e.getMessage());
+        return ResponseEntity.status(statusCode).body(body);
+    }
+
+}

--- a/src/main/java/com/kmong/api/config/advice/ExceptionAdvice.java
+++ b/src/main/java/com/kmong/api/config/advice/ExceptionAdvice.java
@@ -1,7 +1,10 @@
 package com.kmong.api.config.advice;
 
-import com.kmong.api.common.response.Response;
 import com.kmong.api.common.exception.KmongApiException;
+import com.kmong.api.common.exception.KmongNotFoundException;
+import com.kmong.api.common.exception.KmongNotFoundListException;
+import com.kmong.api.common.response.ListResponse;
+import com.kmong.api.common.response.Response;
 import com.kmong.api.common.response.ValidationExceptionResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +30,19 @@ public class ExceptionAdvice {
             response.addValidation(fieldError.getField(), fieldError.getDefaultMessage());
         }
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(KmongNotFoundException.class)
+    public ResponseEntity kmongNotFoundException(KmongNotFoundException e) {
+        int statusCode = e.getStatusCode();
+        if (e instanceof KmongNotFoundListException) {
+            ListResponse body = new ListResponse(String.valueOf(statusCode), e.getMessage());
+            KmongNotFoundListException listException = (KmongNotFoundListException) e;
+            body.setObjects(listException.getList());
+            return ResponseEntity.status(statusCode).body(body);
+        } else {
+            return ResponseEntity.status(statusCode).body(new Response(String.valueOf(statusCode), e.getMessage()));
+        }
     }
 
     @ExceptionHandler(KmongApiException.class)

--- a/src/main/java/com/kmong/api/member/controller/MemberController.java
+++ b/src/main/java/com/kmong/api/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
 
 @Slf4j
 @RestController
@@ -24,12 +25,12 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/member/join")
-    public ResponseEntity join(@RequestBody MemberCreate memberCreate) {
+    public ResponseEntity join(@RequestBody @Valid MemberCreate memberCreate) {
         return memberService.join(memberCreate);
     }
 
     @PostMapping("/member/login")
-    public ResponseEntity login(HttpSession session, @RequestBody MemberSearch memberSearch) {
+    public ResponseEntity login(HttpSession session, @RequestBody @Valid MemberSearch memberSearch) {
         return loginService.login(session, memberSearch);
     }
 

--- a/src/main/java/com/kmong/api/member/controller/MemberController.java
+++ b/src/main/java/com/kmong/api/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.kmong.api.member.controller;
 
+import com.kmong.api.common.response.Response;
 import com.kmong.api.member.request.MemberCreate;
 import com.kmong.api.member.request.MemberSearch;
 import com.kmong.api.member.service.LoginService;
@@ -37,7 +38,7 @@ public class MemberController {
     @PostMapping("/member/logout")
     public ResponseEntity logout(HttpSession session) {
         session.invalidate();
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity(new Response("200", "로그아웃에 성공했습니다."), HttpStatus.OK);
     }
 
 }

--- a/src/main/java/com/kmong/api/member/exception/DuplicateMemberException.java
+++ b/src/main/java/com/kmong/api/member/exception/DuplicateMemberException.java
@@ -1,0 +1,17 @@
+package com.kmong.api.member.exception;
+
+import com.kmong.api.common.exception.KmongApiException;
+
+public class DuplicateMemberException extends KmongApiException {
+
+    private static final String MESSAGE = "중복된 아이디 혹은 중복된 이메일의 회원이 존재합니다.";
+
+    public DuplicateMemberException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 409;
+    }
+}

--- a/src/main/java/com/kmong/api/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/kmong/api/member/exception/MemberNotFoundException.java
@@ -1,0 +1,17 @@
+package com.kmong.api.member.exception;
+
+import com.kmong.api.common.exception.KmongApiException;
+
+public class MemberNotFoundException extends KmongApiException {
+
+    private static final String MESSAGE = "존재하지 않는 회원입니다.";
+
+    public MemberNotFoundException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 404;
+    }
+}

--- a/src/main/java/com/kmong/api/member/exception/MemberNotFoundException.java
+++ b/src/main/java/com/kmong/api/member/exception/MemberNotFoundException.java
@@ -1,8 +1,8 @@
 package com.kmong.api.member.exception;
 
-import com.kmong.api.common.exception.KmongApiException;
+import com.kmong.api.common.exception.KmongNotFoundException;
 
-public class MemberNotFoundException extends KmongApiException {
+public class MemberNotFoundException extends KmongNotFoundException {
 
     private static final String MESSAGE = "존재하지 않는 회원입니다.";
 
@@ -10,8 +10,4 @@ public class MemberNotFoundException extends KmongApiException {
         super(MESSAGE);
     }
 
-    @Override
-    public int getStatusCode() {
-        return 404;
-    }
 }

--- a/src/main/java/com/kmong/api/member/exception/WrongPasswordException.java
+++ b/src/main/java/com/kmong/api/member/exception/WrongPasswordException.java
@@ -1,0 +1,19 @@
+package com.kmong.api.member.exception;
+
+
+import com.kmong.api.common.exception.KmongApiException;
+
+public class WrongPasswordException extends KmongApiException {
+
+    private static final String MESSAGE = "비밀번호가 일치하지 않습니다.";
+
+    public WrongPasswordException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 400;
+    }
+
+}

--- a/src/main/java/com/kmong/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/kmong/api/member/repository/MemberRepository.java
@@ -62,7 +62,7 @@ public class MemberRepository {
      */
     public boolean isAlreadyExist(MemberCreate memberCreate) {
         List<Member> alreadyExistMembers = queryFactory.selectFrom(member)
-                .where(isSameId(memberCreate.getId()).or(isSameEmail(memberCreate.getEmail())))
+                .where(isSameId(memberCreate.getMemberId()).or(isSameEmail(memberCreate.getEmail())))
                 .fetch();
         return !CollectionUtils.isEmpty(alreadyExistMembers);
     }

--- a/src/main/java/com/kmong/api/member/repository/MemberRepository.java
+++ b/src/main/java/com/kmong/api/member/repository/MemberRepository.java
@@ -1,12 +1,17 @@
 package com.kmong.api.member.repository;
 
 import com.kmong.api.member.domain.Member;
+import com.kmong.api.member.request.MemberCreate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.util.StringUtils;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.CollectionUtils;
 
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
+import java.util.List;
 import java.util.Optional;
 
 import static com.kmong.api.member.domain.QMember.member;
@@ -48,5 +53,25 @@ public class MemberRepository {
      */
     public Optional<Member> findById(String id) {
         return Optional.ofNullable(em.find(Member.class, id));
+    }
+
+    /**
+     * 아이디와 이메일 중복 여부 조회
+     * @param memberCreate 중복 여부를 조회할 회원 정보
+     * @return 중복 여부
+     */
+    public boolean isAlreadyExist(MemberCreate memberCreate) {
+        List<Member> alreadyExistMembers = queryFactory.selectFrom(member)
+                .where(isSameId(memberCreate.getId()).or(isSameEmail(memberCreate.getEmail())))
+                .fetch();
+        return !CollectionUtils.isEmpty(alreadyExistMembers);
+    }
+
+    private BooleanExpression isSameId(String id) {
+        return StringUtils.isNullOrEmpty(id) ? null : member.id.equalsIgnoreCase(id);
+    }
+
+    private BooleanExpression isSameEmail(String email) {
+        return StringUtils.isNullOrEmpty(email) ? null : member.email.equalsIgnoreCase(email);
     }
 }

--- a/src/main/java/com/kmong/api/member/request/MemberCreate.java
+++ b/src/main/java/com/kmong/api/member/request/MemberCreate.java
@@ -18,7 +18,7 @@ public class MemberCreate {
     @Pattern(regexp = "^[a-zA-Z][a-zA-Z0-9]*$", message = "아이디는 첫시작을 영어로, 구성은 영숫자로만 가능합니다.")
     @NotNull(message = "아이디는 필수항목입니다.")
     @Size(min = 1, max = 15, message = "아이디는 1자부터 15자까지 가능합니다.")
-    private String id;
+    private String memberId;
 
     @NotNull(message = "이메일은 필수항목입니다.")
     @Size(min = 1, message = "이메일을 입력해주세요.")
@@ -30,15 +30,15 @@ public class MemberCreate {
     private String pwd;
 
     @Builder
-    public MemberCreate(String id, String email, String pwd) {
-        this.id = id;
+    public MemberCreate(String memberId, String email, String pwd) {
+        this.memberId = memberId;
         this.email = email;
         this.pwd = pwd;
     }
 
     public Member toMember() {
         return Member.builder()
-                    .id(id)
+                    .id(memberId)
                     .email(email)
                     .pwd(PwdEncryption.encrypt(pwd))
                     .build();

--- a/src/main/java/com/kmong/api/member/request/MemberCreate.java
+++ b/src/main/java/com/kmong/api/member/request/MemberCreate.java
@@ -8,12 +8,14 @@ import lombok.Setter;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
 @Setter
 public class MemberCreate {
 
+    @Pattern(regexp = "^[a-zA-Z][a-zA-Z0-9]*$", message = "아이디는 첫시작을 영어로, 구성은 영숫자로만 가능합니다.")
     @NotNull(message = "아이디는 필수항목입니다.")
     @Size(min = 1, max = 15, message = "아이디는 1자부터 15자까지 가능합니다.")
     private String id;

--- a/src/main/java/com/kmong/api/member/request/MemberCreate.java
+++ b/src/main/java/com/kmong/api/member/request/MemberCreate.java
@@ -6,12 +6,25 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 @Getter
 @Setter
 public class MemberCreate {
 
+    @NotNull(message = "아이디는 필수항목입니다.")
+    @Size(min = 1, max = 15, message = "아이디는 1자부터 15자까지 가능합니다.")
     private String id;
+
+    @NotNull(message = "이메일은 필수항목입니다.")
+    @Size(min = 1, message = "이메일을 입력해주세요.")
+    @Email(message = "잘못된 이메일 형식입니다.")
     private String email;
+
+    @NotNull(message = "비밀번호는 필수항목입니다.")
+    @Size(min = 1, max = 15, message = "비밀번호는 1자부터 15자까지 가능합니다.")
     private String pwd;
 
     @Builder

--- a/src/main/java/com/kmong/api/member/request/MemberSearch.java
+++ b/src/main/java/com/kmong/api/member/request/MemberSearch.java
@@ -13,15 +13,15 @@ public class MemberSearch {
 
     @NotNull
     @Size(min = 1, max = 15, message = "아이디는 1자부터 15자까지 가능합니다.")
-    private String id;
+    private String memberId;
 
     @NotNull
     @Size(min = 1, max = 15, message = "비밀번호는 1자부터 15자까지 가능합니다.")
     private String pwd;
 
     @Builder
-    public MemberSearch(String id, String pwd) {
-        this.id = id;
+    public MemberSearch(String memberId, String pwd) {
+        this.memberId = memberId;
         this.pwd = pwd;
     }
 }

--- a/src/main/java/com/kmong/api/member/request/MemberSearch.java
+++ b/src/main/java/com/kmong/api/member/request/MemberSearch.java
@@ -4,18 +4,24 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 @Getter
 @Setter
 public class MemberSearch {
 
+    @NotNull
+    @Size(min = 1, max = 15, message = "아이디는 1자부터 15자까지 가능합니다.")
     private String id;
-    private String email;
+
+    @NotNull
+    @Size(min = 1, max = 15, message = "비밀번호는 1자부터 15자까지 가능합니다.")
     private String pwd;
 
     @Builder
-    public MemberSearch(String id, String email, String pwd) {
+    public MemberSearch(String id, String pwd) {
         this.id = id;
-        this.email = email;
         this.pwd = pwd;
     }
 }

--- a/src/main/java/com/kmong/api/member/service/impl/LoginServiceImpl.java
+++ b/src/main/java/com/kmong/api/member/service/impl/LoginServiceImpl.java
@@ -1,5 +1,6 @@
 package com.kmong.api.member.service.impl;
 
+import com.kmong.api.common.response.SingleResponse;
 import com.kmong.api.config.encrypt.PwdEncryption;
 import com.kmong.api.member.domain.Member;
 import com.kmong.api.member.exception.MemberNotFoundException;
@@ -38,7 +39,12 @@ public class LoginServiceImpl implements LoginService {
             Member memberFindById = memberFromDB.get();
             if (memberFindById.getPwd().equals(PwdEncryption.encrypt(memberSearch.getPwd()))) {
                 httpSession.setAttribute("id", memberFindById.getId());
-                response = new ResponseEntity(memberFindById.toMemberView(), HttpStatus.OK);
+                SingleResponse body = SingleResponse.builder()
+                                                    .code("200")
+                                                    .message("로그인되었습니다.")
+                                                    .object(memberFindById.toMemberView())
+                                                    .build();
+                response = new ResponseEntity(body, HttpStatus.OK);
             } else {
                 throw new WrongPasswordException();
             }

--- a/src/main/java/com/kmong/api/member/service/impl/LoginServiceImpl.java
+++ b/src/main/java/com/kmong/api/member/service/impl/LoginServiceImpl.java
@@ -33,7 +33,7 @@ public class LoginServiceImpl implements LoginService {
     @Override
     public ResponseEntity<MemberView> login(HttpSession httpSession, MemberSearch memberSearch) {
         ResponseEntity response = new ResponseEntity(HttpStatus.OK);
-        Optional<Member> memberFromDB = memberRepository.findById(memberSearch.getId());
+        Optional<Member> memberFromDB = memberRepository.findById(memberSearch.getMemberId());
         if (memberFromDB.isPresent()) {
             Member memberFindById = memberFromDB.get();
             if (memberFindById.getPwd().equals(PwdEncryption.encrypt(memberSearch.getPwd()))) {

--- a/src/main/java/com/kmong/api/member/service/impl/LoginServiceImpl.java
+++ b/src/main/java/com/kmong/api/member/service/impl/LoginServiceImpl.java
@@ -1,8 +1,10 @@
 package com.kmong.api.member.service.impl;
 
 import com.kmong.api.config.encrypt.PwdEncryption;
-import com.kmong.api.member.repository.MemberRepository;
 import com.kmong.api.member.domain.Member;
+import com.kmong.api.member.exception.MemberNotFoundException;
+import com.kmong.api.member.exception.WrongPasswordException;
+import com.kmong.api.member.repository.MemberRepository;
 import com.kmong.api.member.request.MemberSearch;
 import com.kmong.api.member.response.MemberView;
 import com.kmong.api.member.service.LoginService;
@@ -38,12 +40,10 @@ public class LoginServiceImpl implements LoginService {
                 httpSession.setAttribute("id", memberFindById.getId());
                 response = new ResponseEntity(memberFindById.toMemberView(), HttpStatus.OK);
             } else {
-                // 비밀번호가 다른 경우
-                response = new ResponseEntity(HttpStatus.BAD_REQUEST);
+                throw new WrongPasswordException();
             }
         } else {
-            // 찾는 멤버가 존재하지 않는 경우
-            response = new ResponseEntity(HttpStatus.NOT_FOUND);
+            throw new MemberNotFoundException();
         }
         return response;
     }

--- a/src/main/java/com/kmong/api/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/kmong/api/member/service/impl/MemberServiceImpl.java
@@ -1,6 +1,7 @@
 package com.kmong.api.member.service.impl;
 
 import com.kmong.api.member.domain.Member;
+import com.kmong.api.member.exception.DuplicateMemberException;
 import com.kmong.api.member.repository.MemberRepository;
 import com.kmong.api.member.request.MemberCreate;
 import com.kmong.api.member.response.MemberView;
@@ -25,16 +26,16 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public ResponseEntity<MemberView> join(MemberCreate memberCreate) {
-        ResponseEntity response = new ResponseEntity(HttpStatus.OK);
-        Member member = memberCreate.toMember();
-        Optional<Member> savedResult = memberRepository.save(member);
-        if (savedResult.isPresent()) {
-            MemberView memberView = savedResult.get().toMemberView();
-            response = new ResponseEntity(memberView, HttpStatus.OK);
+        ResponseEntity response = new ResponseEntity(HttpStatus.CREATED);
+        if (memberRepository.isAlreadyExist(memberCreate)) {
+            throw new DuplicateMemberException();
         } else {
-            response = new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
+            Member member = memberCreate.toMember();
+            memberRepository.save(member);
+            MemberView memberView = member.toMemberView();
+            response = new ResponseEntity(memberView, HttpStatus.CREATED);
         }
 
-        return new ResponseEntity(memberRepository.save(member), HttpStatus.OK);
+        return response;
     }
 }

--- a/src/main/java/com/kmong/api/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/kmong/api/member/service/impl/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package com.kmong.api.member.service.impl;
 
+import com.kmong.api.common.response.SingleResponse;
 import com.kmong.api.member.domain.Member;
 import com.kmong.api.member.exception.DuplicateMemberException;
 import com.kmong.api.member.repository.MemberRepository;
@@ -33,7 +34,12 @@ public class MemberServiceImpl implements MemberService {
             Member member = memberCreate.toMember();
             memberRepository.save(member);
             MemberView memberView = member.toMemberView();
-            response = new ResponseEntity(memberView, HttpStatus.CREATED);
+            SingleResponse body = SingleResponse.builder()
+                                                .code("201")
+                                                .message("회원가입되었습니다.")
+                                                .object(member.toMemberView())
+                                                .build();
+            response = new ResponseEntity(body, HttpStatus.CREATED);
         }
 
         return response;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,7 @@ logging.level.org.hibernate.type=TRACE
 
 #Swagger2
 spring.mvc.pathmatch.matching-strategy=ant_path_matcher
+
+#encoding
+server.servlet.encoding.charset=UTF-8
+server.servlet.encoding.force=true

--- a/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
@@ -407,7 +407,8 @@ public class MemberControllerTest {
         session.setAttribute("id", "test1234");
         mockMvc.perform(post("/member/logout")
                 .session(session))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andDo(MockMvcResultHandlers.print());
         assertTrue(session.isInvalid());
     }
 

--- a/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
@@ -53,7 +53,7 @@ public class MemberControllerTest {
     @DisplayName("회원가입")
     void join() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
-                                                .id("test1234")
+                                                .memberId("test1234")
                                                 .email("test1234@kmong.co.kr")
                                                 .pwd("test1234")
                                                 .build();
@@ -62,10 +62,10 @@ public class MemberControllerTest {
                         .content(objectMapper.writeValueAsString(memberCreate)))
                         .andExpect(status().isCreated());
 
-        Optional<Member> memberFindById = memberRepository.findById(memberCreate.getId());
+        Optional<Member> memberFindById = memberRepository.findById(memberCreate.getMemberId());
         Member member = memberFindById.isPresent() ? memberFindById.get() : null;
 
-        assertEquals(memberCreate.getId(), member.getId());
+        assertEquals(memberCreate.getMemberId(), member.getId());
         assertEquals(memberCreate.getEmail(), member.getEmail());
         assertEquals(PwdEncryption.encrypt(memberCreate.getPwd()), member.getPwd());
     }
@@ -87,7 +87,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals("id", key);
+            assertEquals("memberId", key);
         });
     }
 
@@ -95,7 +95,7 @@ public class MemberControllerTest {
     @DisplayName("15자이상 아이디 회원가입 시도")
     void joinOversizeId() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
-                .id("test1234test1234test1234test1234")
+                .memberId("test1234test1234test1234test1234")
                 .email("test1234@kmong.co.kr")
                 .pwd("test1234")
                 .build();
@@ -109,7 +109,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals("id", key);
+            assertEquals("memberId", key);
         });
     }
 
@@ -117,7 +117,7 @@ public class MemberControllerTest {
     @DisplayName("공백포함 아이디 회원가입 시도")
     void joinIdWithWhitespace() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
-                .id("test 1234")
+                .memberId("test 1234")
                 .email("test1234@kmong.co.kr")
                 .pwd("test1234")
                 .build();
@@ -131,7 +131,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals("id", key);
+            assertEquals("memberId", key);
         });
     }
 
@@ -139,7 +139,7 @@ public class MemberControllerTest {
     @DisplayName("특수문자포함 아이디 회원가입 시도")
     void joinIdWithSpecialCharacters() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
-                .id("test♀1234")
+                .memberId("test♀1234")
                 .email("test1234@kmong.co.kr")
                 .pwd("test1234")
                 .build();
@@ -153,7 +153,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals("id", key);
+            assertEquals("memberId", key);
         });
     }
 
@@ -161,7 +161,7 @@ public class MemberControllerTest {
     @DisplayName("숫자로 시작하는 아이디 회원가입 시도")
     void joinIdThatStartsNumber() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
-                .id("1test1234")
+                .memberId("1test1234")
                 .email("test1234@kmong.co.kr")
                 .pwd("test1234")
                 .build();
@@ -175,7 +175,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals("id", key);
+            assertEquals("memberId", key);
         });
     }
 
@@ -183,7 +183,7 @@ public class MemberControllerTest {
     @DisplayName("비밀번호없이 회원가입 시도")
     void joinWithoutPwd() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
-                .id("test1234")
+                .memberId("test1234")
                 .email("test1234@kmong.co.kr")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
@@ -204,7 +204,7 @@ public class MemberControllerTest {
     @DisplayName("15자이상 비밀번호 회원가입 시도")
     void joinOversizePwd() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
-                .id("test1234")
+                .memberId("test1234")
                 .email("test1234@kmong.co.kr")
                 .pwd("test1234test1234test1234test1234")
                 .build();
@@ -226,7 +226,7 @@ public class MemberControllerTest {
     @DisplayName("이메일없이 회원가입 시도")
     void joinWithoutEmail() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
-                .id("test1234")
+                .memberId("test1234")
                 .pwd("test1234")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
@@ -247,7 +247,7 @@ public class MemberControllerTest {
     @DisplayName("띄어쓰기포함인 이메일로 회원가입 시도")
     void joinEmailWithWhitespace() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
-                .id("test1234")
+                .memberId("test1234")
                 .email("test 1234@kmong.co.kr")
                 .pwd("test1234")
                 .build();
@@ -276,7 +276,7 @@ public class MemberControllerTest {
                                 .sessionId("sessionId").build();
         memberRepository.save(member);
 
-        MemberSearch memberSearch = MemberSearch.builder().id(member.getId()).pwd(pwd).build();
+        MemberSearch memberSearch = MemberSearch.builder().memberId(member.getId()).pwd(pwd).build();
 
         mockMvc.perform(post("/member/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -287,7 +287,7 @@ public class MemberControllerTest {
     @Test
     @DisplayName("존재하지 않는 아이디로 로그인 시도")
     void loginNotExistsId() throws Exception {
-        MemberSearch memberSearch = MemberSearch.builder().id("test1234").pwd("test1234").build();
+        MemberSearch memberSearch = MemberSearch.builder().memberId("test1234").pwd("test1234").build();
 
         mockMvc.perform(post("/member/login")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -308,7 +308,7 @@ public class MemberControllerTest {
 
         String wrongPwd = String.format("%s1", member.getPwd());
         MemberSearch memberSearch = MemberSearch.builder()
-                                                .id(member.getId())
+                                                .memberId(member.getId())
                                                 .pwd(wrongPwd)
                                                 .build();
 
@@ -334,7 +334,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals("id", key);
+            assertEquals("memberId", key);
         });
     }
 
@@ -342,7 +342,7 @@ public class MemberControllerTest {
     @DisplayName("15자이상 아이디로 로그인 시도")
     void loginOversizeId() throws Exception {
         MemberSearch memberSearch = MemberSearch.builder()
-                                                .id("test1234test1234test1234test1234")
+                                                .memberId("test1234test1234test1234test1234")
                                                 .pwd("test1234")
                                                 .build();
 
@@ -355,7 +355,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals("id", key);
+            assertEquals("memberId", key);
         });
     }
 
@@ -363,7 +363,7 @@ public class MemberControllerTest {
     @DisplayName("비밀번호없이 로그인 시도")
     void loginWithoutPwd() throws Exception {
         MemberSearch memberSearch = MemberSearch.builder()
-                .id("test1234")
+                .memberId("test1234")
                 .build();
 
         MvcResult mvcResult = mockMvc.perform(post("/member/login")
@@ -383,7 +383,7 @@ public class MemberControllerTest {
     @DisplayName("15자이상 비밀번호 로그인 시도")
     void loginOversizePwd() throws Exception {
         MemberSearch memberSearch = MemberSearch.builder()
-                .id("test1234")
+                .memberId("test1234")
                 .pwd("test1234test1234test1234test1234")
                 .build();
 

--- a/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
@@ -124,9 +124,9 @@ public class MemberControllerTest {
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(memberCreate)))
-                .andExpect(status().isBadRequest())
-                .andDo(MockMvcResultHandlers.print())
-                .andReturn();
+                        .andExpect(status().isBadRequest())
+                        .andDo(MockMvcResultHandlers.print())
+                        .andReturn();
 
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();

--- a/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
@@ -87,7 +87,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals(key, "id");
+            assertEquals("id", key);
         });
     }
 
@@ -109,7 +109,73 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals(key, "id");
+            assertEquals("id", key);
+        });
+    }
+
+    @Test
+    @DisplayName("공백포함 아이디 회원가입 시도")
+    void joinIdWithWhitespace() throws Exception {
+        MemberCreate memberCreate = MemberCreate.builder()
+                .id("test 1234")
+                .email("test1234@kmong.co.kr")
+                .pwd("test1234")
+                .build();
+        MvcResult mvcResult = mockMvc.perform(post("/member/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberCreate)))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
+        Map<String, String> validation = response.getValidation();
+        validation.forEach((key, value) -> {
+            assertEquals("id", key);
+        });
+    }
+
+    @Test
+    @DisplayName("특수문자포함 아이디 회원가입 시도")
+    void joinIdWithSpecialCharacters() throws Exception {
+        MemberCreate memberCreate = MemberCreate.builder()
+                .id("test♀1234")
+                .email("test1234@kmong.co.kr")
+                .pwd("test1234")
+                .build();
+        MvcResult mvcResult = mockMvc.perform(post("/member/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberCreate)))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
+        Map<String, String> validation = response.getValidation();
+        validation.forEach((key, value) -> {
+            assertEquals("id", key);
+        });
+    }
+
+    @Test
+    @DisplayName("숫자로 시작하는 아이디 회원가입 시도")
+    void joinIdThatStartsNumber() throws Exception {
+        MemberCreate memberCreate = MemberCreate.builder()
+                .id("1test1234")
+                .email("test1234@kmong.co.kr")
+                .pwd("test1234")
+                .build();
+        MvcResult mvcResult = mockMvc.perform(post("/member/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberCreate)))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
+        Map<String, String> validation = response.getValidation();
+        validation.forEach((key, value) -> {
+            assertEquals("id", key);
         });
     }
 
@@ -130,7 +196,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals(key, "pwd");
+            assertEquals("pwd", key);
         });
     }
 
@@ -152,7 +218,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals(key, "pwd");
+            assertEquals("pwd", key);
         });
     }
 
@@ -173,7 +239,29 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals(key, "email");
+            assertEquals("email", key);
+        });
+    }
+
+    @Test
+    @DisplayName("띄어쓰기포함인 이메일로 회원가입 시도")
+    void joinEmailWithWhitespace() throws Exception {
+        MemberCreate memberCreate = MemberCreate.builder()
+                .id("test1234")
+                .email("test 1234@kmong.co.kr")
+                .pwd("test1234")
+                .build();
+        MvcResult mvcResult = mockMvc.perform(post("/member/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(memberCreate)))
+                .andExpect(status().isBadRequest())
+                .andDo(MockMvcResultHandlers.print())
+                .andReturn();
+
+        ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
+        Map<String, String> validation = response.getValidation();
+        validation.forEach((key, value) -> {
+            assertEquals("email", key);
         });
     }
 
@@ -246,7 +334,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals(key, "id");
+            assertEquals("id", key);
         });
     }
 
@@ -267,7 +355,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals(key, "id");
+            assertEquals("id", key);
         });
     }
 
@@ -287,7 +375,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals(key, "pwd");
+            assertEquals("pwd", key);
         });
     }
 
@@ -308,7 +396,7 @@ public class MemberControllerTest {
         ValidationExceptionResponse response = objectMapper.readValue(mvcResult.getResponse().getContentAsString(), ValidationExceptionResponse.class);
         Map<String, String> validation = response.getValidation();
         validation.forEach((key, value) -> {
-            assertEquals(key, "pwd");
+            assertEquals("pwd", key);
         });
     }
 

--- a/src/test/java/com/kmong/api/member/service/LoginServiceTest.java
+++ b/src/test/java/com/kmong/api/member/service/LoginServiceTest.java
@@ -1,11 +1,10 @@
 package com.kmong.api.member.service;
 
 import com.kmong.api.config.encrypt.PwdEncryption;
-import com.kmong.api.member.repository.MemberRepository;
 import com.kmong.api.member.domain.Member;
+import com.kmong.api.member.exception.MemberNotFoundException;
+import com.kmong.api.member.repository.MemberRepository;
 import com.kmong.api.member.request.MemberSearch;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +16,7 @@ import org.springframework.mock.web.MockHttpSession;
 import javax.transaction.Transactional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SpringBootTest
 @Transactional
@@ -54,37 +54,35 @@ public class LoginServiceTest {
     @Test
     @DisplayName("존재하지 않는 아이디로 로그인 시도")
     void loginNotExistsId() {
-        MemberSearch memberSearch = MemberSearch.builder()
-                                                .id("test1234")
-                                                .pwd("test1234")
-                                                .build();
-        ResponseEntity response = loginService.login(new MockHttpSession(), memberSearch);
-
-        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        assertThrows(MemberNotFoundException.class, () -> {
+            MemberSearch memberSearch = MemberSearch.builder()
+                    .id("test1234")
+                    .pwd("test1234")
+                    .build();
+            loginService.login(new MockHttpSession(), memberSearch);
+        });
     }
 
     @Test
     @DisplayName("잘못된 비밀번호로 로그인 시도")
     void loginWrongPwd() {
-        //given
-        Member member = Member.builder()
-                                .id("test1234")
-                                .email("test1234@naver.com")
-                                .pwd("test1234")
-                                .sessionId("sessionId")
-                                .build();
-        memberRepository.save(member);
+        assertThrows(RuntimeException.class, () -> {
+            Member member = Member.builder()
+                    .id("test1234")
+                    .email("test1234@naver.com")
+                    .pwd("test1234")
+                    .sessionId("sessionId")
+                    .build();
+            memberRepository.save(member);
 
-        //when
-        String wrongPwd = String.format("%s1", member.getPwd());
-        MemberSearch memberSearch = MemberSearch.builder()
-                                                .id("test1234")
-                                                .pwd(wrongPwd)
-                                                .build();
-        ResponseEntity response = loginService.login(new MockHttpSession(), memberSearch);
-
-        //then
-        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+            //when
+            String wrongPwd = String.format("%s1", member.getPwd());
+            MemberSearch memberSearch = MemberSearch.builder()
+                    .id("test1234")
+                    .pwd(wrongPwd)
+                    .build();
+            loginService.login(new MockHttpSession(), memberSearch);
+        });
     }
 
 }

--- a/src/test/java/com/kmong/api/member/service/LoginServiceTest.java
+++ b/src/test/java/com/kmong/api/member/service/LoginServiceTest.java
@@ -42,7 +42,7 @@ public class LoginServiceTest {
 
         //when
         MemberSearch memberSearch = MemberSearch.builder()
-                                                .id("test1234")
+                                                .memberId("test1234")
                                                 .pwd("test1234")
                                                 .build();
         ResponseEntity response = loginService.login(new MockHttpSession(), memberSearch);
@@ -56,7 +56,7 @@ public class LoginServiceTest {
     void loginNotExistsId() {
         assertThrows(MemberNotFoundException.class, () -> {
             MemberSearch memberSearch = MemberSearch.builder()
-                    .id("test1234")
+                    .memberId("test1234")
                     .pwd("test1234")
                     .build();
             loginService.login(new MockHttpSession(), memberSearch);
@@ -78,7 +78,7 @@ public class LoginServiceTest {
             //when
             String wrongPwd = String.format("%s1", member.getPwd());
             MemberSearch memberSearch = MemberSearch.builder()
-                    .id("test1234")
+                    .memberId("test1234")
                     .pwd(wrongPwd)
                     .build();
             loginService.login(new MockHttpSession(), memberSearch);

--- a/src/test/java/com/kmong/api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kmong/api/member/service/MemberServiceTest.java
@@ -2,7 +2,6 @@ package com.kmong.api.member.service;
 
 import com.kmong.api.config.encrypt.PwdEncryption;
 import com.kmong.api.member.domain.Member;
-import com.kmong.api.member.repository.MemberRepository;
 import com.kmong.api.member.request.MemberCreate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import javax.transaction.Transactional;
-
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,7 +35,7 @@ public class MemberServiceTest {
         Optional<Member> memberFindById = memberService.findById(memberCreate.getId());
         Member member = memberFindById.isPresent() ? memberFindById.get() : null;
 
-        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
         assertEquals(memberCreate.getId(), member.getId());
         assertEquals(memberCreate.getEmail(), member.getEmail());
         assertEquals(PwdEncryption.encrypt(memberCreate.getPwd()), member.getPwd());

--- a/src/test/java/com/kmong/api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kmong/api/member/service/MemberServiceTest.java
@@ -26,17 +26,17 @@ public class MemberServiceTest {
     @DisplayName("회원가입")
     void join() {
         MemberCreate memberCreate = MemberCreate.builder()
-                                                .id("test1234")
+                                                .memberId("test1234")
                                                 .email("test1234@kmong.co.kr")
                                                 .pwd("test1234")
                                                 .build();
         ResponseEntity response = memberService.join(memberCreate);
 
-        Optional<Member> memberFindById = memberService.findById(memberCreate.getId());
+        Optional<Member> memberFindById = memberService.findById(memberCreate.getMemberId());
         Member member = memberFindById.isPresent() ? memberFindById.get() : null;
 
         assertEquals(HttpStatus.CREATED, response.getStatusCode());
-        assertEquals(memberCreate.getId(), member.getId());
+        assertEquals(memberCreate.getMemberId(), member.getId());
         assertEquals(memberCreate.getEmail(), member.getEmail());
         assertEquals(PwdEncryption.encrypt(memberCreate.getPwd()), member.getPwd());
     }


### PR DESCRIPTION
1. 회원 유효성체크 로직 추가
 - 아이디 1~15자
 - 이메일 형식에 맞춰서
 - 비밀번호 1~15자
2. 응답 보완
 - 회원가입, 로그인, 로그아웃 등의 응답에 상태코드, 메시지 포함되도록 수정
3. 예외 처리
 - 예외 커스텀하여 사용