### PR TITLE
유효성체크 조건 변경

### DIFF
--- a/src/main/java/com/kmong/api/member/request/MemberCreate.java
+++ b/src/main/java/com/kmong/api/member/request/MemberCreate.java
@@ -6,17 +6,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
 
 @Getter
 @Setter
 public class MemberCreate {
 
     @Pattern(regexp = "^[a-zA-Z][a-zA-Z0-9]*$", message = "아이디는 첫시작을 영어로, 구성은 영숫자로만 가능합니다.")
-    @NotNull(message = "아이디는 필수항목입니다.")
+    @NotBlank(message = "아이디는 필수항목입니다.")
     @Size(min = 1, max = 15, message = "아이디는 1자부터 15자까지 가능합니다.")
     private String memberId;
 
@@ -25,7 +22,8 @@ public class MemberCreate {
     @Email(message = "잘못된 이메일 형식입니다.")
     private String email;
 
-    @NotNull(message = "비밀번호는 필수항목입니다.")
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자 조합으로만 가능합니다.")
+    @NotBlank(message = "비밀번호는 필수항목입니다.")
     @Size(min = 1, max = 15, message = "비밀번호는 1자부터 15자까지 가능합니다.")
     private String pwd;
 

--- a/src/main/java/com/kmong/api/member/request/MemberSearch.java
+++ b/src/main/java/com/kmong/api/member/request/MemberSearch.java
@@ -5,16 +5,19 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 @Getter
 @Setter
 public class MemberSearch {
 
+    @Pattern(regexp = "^[a-zA-Z][a-zA-Z0-9]*$", message = "아이디는 첫시작을 영어로, 구성은 영숫자로만 가능합니다.")
     @NotBlank(message = "아이디는 필수항목입니다.")
     @Size(min = 1, max = 15, message = "아이디는 1자부터 15자까지 가능합니다.")
     private String memberId;
 
+    @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,16}", message = "비밀번호는 8~16자 영문 대 소문자, 숫자, 특수문자 조합으로만 가능합니다.")
     @NotBlank(message = "비밀번호는 필수항목입니다.")
     @Size(min = 1, max = 15, message = "비밀번호는 1자부터 15자까지 가능합니다.")
     private String pwd;

--- a/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/kmong/api/member/controller/MemberControllerTest.java
@@ -55,7 +55,7 @@ public class MemberControllerTest {
         MemberCreate memberCreate = MemberCreate.builder()
                                                 .memberId("test1234")
                                                 .email("test1234@kmong.co.kr")
-                                                .pwd("test1234")
+                                                .pwd("Test@1234")
                                                 .build();
         mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -75,7 +75,7 @@ public class MemberControllerTest {
     void joinWithoutId() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
                 .email("test1234@kmong.co.kr")
-                .pwd("test1234")
+                .pwd("Test@1234")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -97,7 +97,7 @@ public class MemberControllerTest {
         MemberCreate memberCreate = MemberCreate.builder()
                 .memberId("test1234test1234test1234test1234")
                 .email("test1234@kmong.co.kr")
-                .pwd("test1234")
+                .pwd("Test@1234")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -119,7 +119,7 @@ public class MemberControllerTest {
         MemberCreate memberCreate = MemberCreate.builder()
                 .memberId("test 1234")
                 .email("test1234@kmong.co.kr")
-                .pwd("test1234")
+                .pwd("Test@1234")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -141,7 +141,7 @@ public class MemberControllerTest {
         MemberCreate memberCreate = MemberCreate.builder()
                 .memberId("test♀1234")
                 .email("test1234@kmong.co.kr")
-                .pwd("test1234")
+                .pwd("Test@1234")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -163,7 +163,7 @@ public class MemberControllerTest {
         MemberCreate memberCreate = MemberCreate.builder()
                 .memberId("1test1234")
                 .email("test1234@kmong.co.kr")
-                .pwd("test1234")
+                .pwd("Test@1234")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -206,7 +206,7 @@ public class MemberControllerTest {
         MemberCreate memberCreate = MemberCreate.builder()
                 .memberId("test1234")
                 .email("test1234@kmong.co.kr")
-                .pwd("test1234test1234test1234test1234")
+                .pwd("Test@1234Test@1234Test@1234Test@1234Test@1234")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -227,7 +227,7 @@ public class MemberControllerTest {
     void joinWithoutEmail() throws Exception {
         MemberCreate memberCreate = MemberCreate.builder()
                 .memberId("test1234")
-                .pwd("test1234")
+                .pwd("Test@1234")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -249,7 +249,7 @@ public class MemberControllerTest {
         MemberCreate memberCreate = MemberCreate.builder()
                 .memberId("test1234")
                 .email("test 1234@kmong.co.kr")
-                .pwd("test1234")
+                .pwd("Test@1234")
                 .build();
         MvcResult mvcResult = mockMvc.perform(post("/member/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -268,7 +268,7 @@ public class MemberControllerTest {
     @Test
     @DisplayName("로그인")
     void login() throws Exception {
-        String pwd = "test1234";
+        String pwd = "Test@1234";
         Member member = Member.builder()
                                 .id("test1234")
                                 .email("test1234@naver.com")
@@ -287,7 +287,7 @@ public class MemberControllerTest {
     @Test
     @DisplayName("존재하지 않는 아이디로 로그인 시도")
     void loginNotExistsId() throws Exception {
-        MemberSearch memberSearch = MemberSearch.builder().memberId("test1234").pwd("test1234").build();
+        MemberSearch memberSearch = MemberSearch.builder().memberId("test1234").pwd("Test@1234").build();
 
         mockMvc.perform(post("/member/login")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -301,7 +301,7 @@ public class MemberControllerTest {
         Member member = Member.builder()
                 .id("test1234")
                 .email("test1234@naver.com")
-                .pwd("test1234")
+                .pwd("Test@1234")
                 .sessionId("sessionId")
                 .build();
         memberRepository.save(member);
@@ -322,7 +322,7 @@ public class MemberControllerTest {
     @DisplayName("아이디없이 로그인 시도")
     void loginWithoutId() throws Exception {
         MemberSearch memberSearch = MemberSearch.builder()
-                .pwd("test1234")
+                .pwd("Test@1234")
                 .build();
 
         MvcResult mvcResult = mockMvc.perform(post("/member/login")
@@ -343,7 +343,7 @@ public class MemberControllerTest {
     void loginOversizeId() throws Exception {
         MemberSearch memberSearch = MemberSearch.builder()
                                                 .memberId("test1234test1234test1234test1234")
-                                                .pwd("test1234")
+                                                .pwd("Test@1234")
                                                 .build();
 
         MvcResult mvcResult = mockMvc.perform(post("/member/login")
@@ -384,7 +384,7 @@ public class MemberControllerTest {
     void loginOversizePwd() throws Exception {
         MemberSearch memberSearch = MemberSearch.builder()
                 .memberId("test1234")
-                .pwd("test1234test1234test1234test1234")
+                .pwd("Test@1234Test@1234Test@1234Test@1234Test@1234")
                 .build();
 
         MvcResult mvcResult = mockMvc.perform(post("/member/login")

--- a/src/test/java/com/kmong/api/member/service/LoginServiceTest.java
+++ b/src/test/java/com/kmong/api/member/service/LoginServiceTest.java
@@ -35,7 +35,7 @@ public class LoginServiceTest {
         Member member = Member.builder()
                                 .id("test1234")
                                 .email("test1234@naver.com")
-                                .pwd(PwdEncryption.encrypt("test1234"))
+                                .pwd(PwdEncryption.encrypt("Test@1234"))
                                 .sessionId("sessionId")
                                 .build();
         memberRepository.save(member);
@@ -43,7 +43,7 @@ public class LoginServiceTest {
         //when
         MemberSearch memberSearch = MemberSearch.builder()
                                                 .memberId("test1234")
-                                                .pwd("test1234")
+                                                .pwd("Test@1234")
                                                 .build();
         ResponseEntity response = loginService.login(new MockHttpSession(), memberSearch);
 
@@ -57,7 +57,7 @@ public class LoginServiceTest {
         assertThrows(MemberNotFoundException.class, () -> {
             MemberSearch memberSearch = MemberSearch.builder()
                     .memberId("test1234")
-                    .pwd("test1234")
+                    .pwd("Test@1234")
                     .build();
             loginService.login(new MockHttpSession(), memberSearch);
         });
@@ -70,7 +70,7 @@ public class LoginServiceTest {
             Member member = Member.builder()
                     .id("test1234")
                     .email("test1234@naver.com")
-                    .pwd("test1234")
+                    .pwd("Test@1234")
                     .sessionId("sessionId")
                     .build();
             memberRepository.save(member);

--- a/src/test/java/com/kmong/api/member/service/MemberServiceTest.java
+++ b/src/test/java/com/kmong/api/member/service/MemberServiceTest.java
@@ -28,7 +28,7 @@ public class MemberServiceTest {
         MemberCreate memberCreate = MemberCreate.builder()
                                                 .memberId("test1234")
                                                 .email("test1234@kmong.co.kr")
-                                                .pwd("test1234")
+                                                .pwd("Test@1234")
                                                 .build();
         ResponseEntity response = memberService.join(memberCreate);
 


### PR DESCRIPTION
1. 아이디에 빈 문자열 입력될 경우
[기존]
'아이디는 1자부터 15자까지 가능합니다.'로 표시
[변경]
'아이디는 필수항목입니다.'로 표시

2. 비밀번호에 빈 문자열 입력될 경우
[기존]
'비밀번호는 1자부터 15자까지 가능합니다.'로 표시
[변경]
'비밀번호는 8~16자 영문 대소문자, 숫자, 특수문자 조합으로만 가능합니다.'로 표시