### PR TITLE
본인의 주문내역이 아닌 주문내역 조회를 요청할 경우 조회할 수 없도록 수정

### DIFF
--- a/src/main/java/com/kmong/api/config/advice/ExceptionAdvice.java
+++ b/src/main/java/com/kmong/api/config/advice/ExceptionAdvice.java
@@ -35,7 +35,7 @@ public class ExceptionAdvice {
     public ResponseEntity kmongNotFoundException(KmongApiListException e) {
         int statusCode = e.getStatusCode();
         ListResponse body = new ListResponse(String.valueOf(statusCode), e.getMessage());
-        body.setObjects(e.getList());
+        body.setDatas(e.getList());
         return ResponseEntity.status(statusCode).body(body);
     }
 

--- a/src/main/java/com/kmong/api/order/controller/OrderController.java
+++ b/src/main/java/com/kmong/api/order/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.kmong.api.order.controller;
 
+import com.kmong.api.order.exception.InconsistentMemberException;
 import com.kmong.api.order.request.OrderCreate;
 import com.kmong.api.order.request.OrderSearch;
 import com.kmong.api.order.service.OrderService;
@@ -8,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 
 @Slf4j
@@ -23,7 +25,10 @@ public class OrderController {
     }
 
     @GetMapping("/order/list")
-    public ResponseEntity findAllOrder(@ModelAttribute OrderSearch orderSearch) {
+    public ResponseEntity findAllOrder(HttpSession session, @ModelAttribute OrderSearch orderSearch) {
+        if (!session.getAttribute("id").equals(orderSearch.getMemberId())) {
+            throw new InconsistentMemberException();
+        }
         return orderService.findAllOrder(orderSearch);
     }
 

--- a/src/main/java/com/kmong/api/order/exception/InconsistentMemberException.java
+++ b/src/main/java/com/kmong/api/order/exception/InconsistentMemberException.java
@@ -1,0 +1,17 @@
+package com.kmong.api.order.exception;
+
+import com.kmong.api.common.exception.KmongApiException;
+
+public class InconsistentMemberException extends KmongApiException {
+
+    private static final String MESSAGE = "조회권한이 없습니다. 본인의 주문내역만 조회 가능합니다.";
+
+    public InconsistentMemberException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 400;
+    }
+}


### PR DESCRIPTION
[기존]
본인의 주문내역이 아닌 주문내역을 요청하더라도 조회 가능

[변경]
본인의 주문내역이 아닌 주문내역을 요청할 경우, 아래와 같이 표시
{
    "code": "400",
    "message": "조회권한이 없습니다. 본인의 주문내역만 조회 가능합니다."
}