### PR TITLE
로그인 후 회원가입 시도시 로그아웃 후 회원가입 가능하다는 문구 표시

### DIFF
--- a/src/main/java/com/kmong/api/member/controller/MemberController.java
+++ b/src/main/java/com/kmong/api/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.kmong.api.member.controller;
 
 import com.kmong.api.common.response.Response;
+import com.kmong.api.member.exception.AlreadyLoginException;
 import com.kmong.api.member.request.MemberCreate;
 import com.kmong.api.member.request.MemberSearch;
 import com.kmong.api.member.service.LoginService;
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.ObjectUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,7 +28,10 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/member/join")
-    public ResponseEntity join(@RequestBody @Valid MemberCreate memberCreate) {
+    public ResponseEntity join(HttpSession session, @RequestBody @Valid MemberCreate memberCreate) {
+        if (!ObjectUtils.isEmpty(session.getAttribute("id"))) {
+            throw new AlreadyLoginException();
+        }
         return memberService.join(memberCreate);
     }
 

--- a/src/main/java/com/kmong/api/member/exception/AlreadyLoginException.java
+++ b/src/main/java/com/kmong/api/member/exception/AlreadyLoginException.java
@@ -1,0 +1,18 @@
+package com.kmong.api.member.exception;
+
+import com.kmong.api.common.exception.KmongApiException;
+
+public class AlreadyLoginException extends KmongApiException {
+
+    private static final String MESSAGE = "로그아웃 후 회원가입이 가능합니다.";
+
+    public AlreadyLoginException() {
+        super(MESSAGE);
+    }
+
+    @Override
+    public int getStatusCode() {
+        return 400;
+    }
+
+}


### PR DESCRIPTION
[기존]
로그인 후 회원가입 시도하더라도 가능

[변경]
로그인 후 회원가입 시도시 아래와 같이 표시
{
    "code": "400",
    "message": "로그아웃 후 회원가입이 가능합니다."
}