### PR TITLE
본인이 아닌 멤버아이디로 주문시 예외 처리

### DIFF
--- a/src/main/java/com/kmong/api/order/controller/OrderController.java
+++ b/src/main/java/com/kmong/api/order/controller/OrderController.java
@@ -22,16 +22,23 @@ public class OrderController {
     private final OrderService orderService;
 
     @PostMapping("/order/create")
-    public ResponseEntity createOrder(@RequestBody @Valid OrderCreate orderCreate) {
+    public ResponseEntity createOrder(HttpSession session, @RequestBody @Valid OrderCreate orderCreate) {
+        if (!isSameMember(session, orderCreate.getMemberId())) {
+            throw new InconsistentMemberException();
+        }
         return orderService.createOrder(orderCreate);
     }
 
     @GetMapping("/order/list")
     public ResponseEntity findAllOrder(HttpSession session, @ModelAttribute OrderSearch orderSearch) {
-        if (!session.getAttribute(SESSION_ATTRIBUTE_MEMBER_ID).equals(orderSearch.getMemberId())) {
+        if (!isSameMember(session, orderSearch.getMemberId())) {
             throw new InconsistentMemberException();
         }
         return orderService.findAllOrder(orderSearch);
+    }
+
+    private boolean isSameMember(HttpSession session, String memberId) {
+        return session.getAttribute(SESSION_ATTRIBUTE_MEMBER_ID).equals(memberId);
     }
 
 }

--- a/src/main/java/com/kmong/api/order/exception/InconsistentMemberException.java
+++ b/src/main/java/com/kmong/api/order/exception/InconsistentMemberException.java
@@ -4,7 +4,7 @@ import com.kmong.api.common.exception.KmongApiException;
 
 public class InconsistentMemberException extends KmongApiException {
 
-    private static final String MESSAGE = "조회권한이 없습니다. 본인의 주문내역만 조회 가능합니다.";
+    private static final String MESSAGE = "조회권한이 없습니다.";
 
     public InconsistentMemberException() {
         super(MESSAGE);

--- a/src/main/java/com/kmong/api/order/repository/OrderRepository.java
+++ b/src/main/java/com/kmong/api/order/repository/OrderRepository.java
@@ -45,7 +45,7 @@ public class OrderRepository {
 
     /**
      * 주문내역 전체 조회
-     * @param id 주문내역을 조회할 회원 아이디
+     * @param orderSearch 주문내역을 조회할 정보
      * @return 주문내역 리스트
      */
     public List<Order> findAllOrder(OrderSearch orderSearch) {

--- a/src/main/java/com/kmong/api/order/service/OrderService.java
+++ b/src/main/java/com/kmong/api/order/service/OrderService.java
@@ -15,7 +15,7 @@ public interface OrderService {
 
     /**
      * 주문내역 전체 조회
-     * @param id 주문내역을 조회할 회원 아이디
+     * @param orderSearch 주문내역을 조회할 정보
      * @return 주문내역 조회 결과
      */
     ResponseEntity findAllOrder(OrderSearch orderSearch);


### PR DESCRIPTION
1. 주문시 멤버아이디를 파라미터로 받게 되어있는데, 본인이 아닌 멤버아이디로 주문시 예외 발생하도록 처리